### PR TITLE
Keep Scale-In Threshold Lower than Scale-Out

### DIFF
--- a/index.py
+++ b/index.py
@@ -69,7 +69,7 @@ def update_alarm_out(shards, stream):
 
 #fuction to update scale in alarm threshol
 def update_alarm_in(shards, stream):
-	new_threshold = (1000 * shards * 60)*80/100 #assuming alarm will fire at 80% of incoming records
+	new_threshold = (1000 * (shards-1) * 60)*80/100 #assuming alarm will fire at 80% of incoming records
 	try:
 		set_alarm = client_cloudwatch.put_metric_alarm(
 			AlarmName=CLOUDWATCHALARMNAMEIN,


### PR DESCRIPTION
Issue:
Constant traffic of any level leads to indefinite scale in and out because the threshold is at the same line,
therefore an action is always required.

Changes:
Set the scale-in threshold to a level acceptable for less shards than the current shards count.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
